### PR TITLE
[STEP-10] 동시성 통합 테스트

### DIFF
--- a/src/main/java/kr/hhplus/be/server/domain/coupon/CouponService.java
+++ b/src/main/java/kr/hhplus/be/server/domain/coupon/CouponService.java
@@ -24,7 +24,6 @@ public class CouponService {
         Coupon coupon = couponRepository.findByIdWithLock(couponId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.COUPON_NOT_FOUND,couponId));
 
-        System.out.println("Coupon: " + coupon.getCouponId());
 
         // 사용자 중복 발급 확인
         if(couponRepository.findUserCoupon(userId, couponId).isPresent()){
@@ -41,10 +40,8 @@ public class CouponService {
                 .couponId(couponId)
                 .status(CouponStatus.ACTIVE)
                 .build();
-        System.out.println("UserCoupon before save: " + userCoupon.getUserCouponId());
 
         userCoupon = couponRepository.save(userCoupon);
-        System.out.println("UserCoupon after save: " + userCoupon.getUserCouponId());
 
         return CouponInfo.IssueUserCoupon.from(userCoupon, coupon);
     }

--- a/src/test/java/kr/hhplus/be/server/interfaces/coupon/CouponControllerConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/interfaces/coupon/CouponControllerConcurrencyTest.java
@@ -1,0 +1,131 @@
+package kr.hhplus.be.server.interfaces.coupon;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.hhplus.be.server.domain.coupon.Coupon;
+import kr.hhplus.be.server.domain.user.User;
+import kr.hhplus.be.server.infra.coupon.CouponJpaRepository;
+import kr.hhplus.be.server.infra.user.UserJpaRepository;
+import kr.hhplus.be.server.interfaces.dto.coupon.request.CouponRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class CouponControllerConcurrencyTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private CouponJpaRepository couponJpaRepository;
+
+    @Autowired
+    private UserJpaRepository userJpaRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("동시성 테스트 - 쿠폰 발급, 10명 성공, 11번째 실패")
+    void 재고가_10개인_쿠폰에_11명이_발급신청하면_11번쨰_사용자는_발급_실패() throws Exception{
+        // 테스트 데이터 설정, 쿠폰 재고 10개 & 11명 사용자 생성
+        Long couponId = createTestCoupon(10);
+        List<Long> userIds = createTestUsers(11);
+
+        int threadCount = 11;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(1);
+
+        // 스레드마다 쿠폰 발급 요청을 수행하도록 정의 <- 나중에 동시에 실행함
+        List<Callable<ResultActions>> tasks = new ArrayList<>();
+        for(Long userId : userIds){
+            tasks.add(() -> {
+                latch.await();
+                var issueRequest = new CouponRequest.IssueRequest(
+                        userId,
+                        couponId
+                );
+                String requestJson = objectMapper.writeValueAsString(issueRequest);
+                return mockMvc.perform(post("/api/v1/coupons/issue")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson));
+            });
+        }
+
+        // 모든 작업 제출
+        List<Future<ResultActions>> futures = new ArrayList<>();
+        for(Callable<ResultActions> task : tasks){
+            futures.add(executor.submit(task));
+        }
+
+        latch.countDown();
+        executor.shutdown();
+        executor.awaitTermination(30, TimeUnit.SECONDS);
+
+        // 검증을 위한 결과 수집 및 성공,실패 카운트
+        int successCount = 0;
+        int failCount = 0;
+
+        for(Future<ResultActions> future : futures){
+            try{
+                MvcResult result = future.get().andReturn();
+                int status = result.getResponse().getStatus();
+                if(HttpStatus.OK.value() == status){
+                    successCount++;
+                } else {
+                    failCount++;
+                }
+            } catch (ExecutionException e){
+                failCount++;
+            }
+        }
+        assertThat(successCount).isEqualTo(10);
+        assertThat(failCount).isEqualTo(1);
+    }
+
+    // 테스트 쿠폰 생성 메서드
+    private Long createTestCoupon(int stock){
+        Coupon coupon = Coupon.builder()
+                .name("테스트쿠폰")
+                .discountPrice(1000L)
+                .stock(stock)
+                .expiredAt(LocalDateTime.now().plusDays(7))
+                .build();
+
+        Coupon savedCoupon = couponJpaRepository.save(coupon);
+        return savedCoupon.getCouponId();
+    }
+
+    // 테스트 사용자 생성 메서드
+    private List<Long> createTestUsers(int count){
+        List<Long> userIds = new ArrayList<>();
+        for(int i = 0 ; i<count ; i++){
+            User user = User.builder()
+                    .name("사용자" + i)
+                    .build();
+            user = userJpaRepository.save(user);
+            userIds.add(user.getUserId());
+        }
+        return userIds;
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/interfaces/coupon/CouponControllerIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/interfaces/coupon/CouponControllerIntegrationTest.java
@@ -1,0 +1,134 @@
+package kr.hhplus.be.server.interfaces.coupon;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.hhplus.be.server.domain.coupon.Coupon;
+import kr.hhplus.be.server.domain.user.User;
+import kr.hhplus.be.server.infra.coupon.CouponJpaRepository;
+import kr.hhplus.be.server.infra.user.UserJpaRepository;
+import kr.hhplus.be.server.interfaces.dto.coupon.request.CouponRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class CouponControllerIntegrationTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private CouponJpaRepository couponJpaRepository;
+
+    @Autowired
+    private UserJpaRepository userJpaRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private Long testUserId;
+    private Long testCouponId;
+
+    @BeforeEach
+    void setUp() {
+        // 데이터베이스 초기화
+        couponJpaRepository.deleteAll();
+        userJpaRepository.deleteAll();
+
+        User user = User.builder()
+                .name("테스트사용자")
+                .build();
+        user = userJpaRepository.save(user);
+        testUserId = user.getUserId();
+
+        // 테스트 쿠폰 생성
+        Coupon coupon = Coupon.builder()
+                .name("테스트쿠폰")
+                .discountPrice(1000L)
+                .stock(10)
+                .expiredAt(LocalDateTime.now().plusDays(7))
+                .build();
+        coupon = couponJpaRepository.save(coupon);
+        testCouponId = coupon.getCouponId();
+    }
+
+    @Test
+    @DisplayName("[POST] /api/v1/coupons/issue - 쿠폰 발급 성공")
+    void 사용자_아이디와_쿠폰_아이디를_전달하면_쿠폰이_발급된다() throws Exception{
+        // given
+        var issueRequest = new CouponRequest.IssueRequest(
+                testUserId,
+                testCouponId
+        );
+        String requestJson = objectMapper.writeValueAsString(issueRequest);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/coupons/issue")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.userCouponId").exists())
+                .andExpect(jsonPath("$.data.couponName").value("테스트쿠폰"))
+                .andExpect(jsonPath("$.data.discountAmount").value(1000))
+                .andExpect(jsonPath("$.data.status").exists());
+    }
+
+    @Test
+    @DisplayName("[GET] /api/v1/coupons/users/{userId} - 사용자 쿠폰 목록 조회 성공")
+    void 사용자_아이디와_쿠폰_아이디를_전달하면_사용자_보유쿠폰목록_조회_성공() throws Exception{
+        // given -> 검증 시 여러개의 쿠폰 발급 목록을 확인하기 위한 작업
+        List<Coupon> coupons = new ArrayList<>();
+        int couponCount = 5;
+        for(int i = 1; i<couponCount; i++){
+            Coupon coupon = Coupon.builder()
+                    .name("테스트쿠폰"+i)
+                    .discountPrice(1000L*i)
+                    .stock(10)
+                    .expiredAt(LocalDateTime.now().plusDays(7))
+                    .build();
+            coupons.add(couponJpaRepository.save(coupon));
+            var issueRequest = new CouponRequest.IssueRequest(
+                    testUserId,
+                    coupon.getCouponId()
+            );
+            String requestJson = objectMapper.writeValueAsString(issueRequest);
+            mockMvc.perform(post("/api/v1/coupons/issue")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestJson))
+                    .andExpect(status().isOk());
+        }
+
+        // when
+        var response = mockMvc.perform(get("/api/v1/coupons/users/{userId}", testUserId));
+
+        // then
+        response.andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(coupons.size()));
+
+                for(int i = 0; i<coupons.size(); i++){
+                    response.andExpect(jsonPath("$.data[" + i + "].couponName").value("테스트쿠폰" + (i + 1)))
+                            .andExpect(jsonPath("$.data[" + i + "].discountPrice").value(1000L * (i + 1)));
+                }
+
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/interfaces/order/OrderControllerIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/interfaces/order/OrderControllerIntegrationTest.java
@@ -1,0 +1,89 @@
+package kr.hhplus.be.server.interfaces.order;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.hhplus.be.server.domain.product.Product;
+import kr.hhplus.be.server.infra.order.OrderJpaRepository;
+import kr.hhplus.be.server.infra.order.OrderLineJpaRepository;
+import kr.hhplus.be.server.infra.product.ProductJpaRepository;
+import kr.hhplus.be.server.interfaces.dto.order.request.OrderRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.http.MediaType;
+
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class OrderControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ProductJpaRepository productJpaRepository;
+
+    @Autowired
+    private OrderJpaRepository orderJpaRepository;
+
+    @Autowired
+    private OrderLineJpaRepository orderLineJpaRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private Long testProductId;
+
+    @BeforeEach
+    void setUp(){
+        // 데이터베이스 초기화
+        orderLineJpaRepository.deleteAll();
+        orderJpaRepository.deleteAll();
+        productJpaRepository.deleteAll();
+
+        // 테스트 상품 생성
+        Product product = Product.builder()
+                .name("테스트 상품")
+                .price(50000L)
+                .stock(100)
+                .status(kr.hhplus.be.server.support.constant.ProductStatus.ON_SALE)
+                .build();
+        product = productJpaRepository.save(product);
+        testProductId = product.getProductId();
+    }
+
+    @Test
+    @DisplayName("[POST] /api/v1/orders - 주문 생성 성공 테스트")
+    void 사용자아이디와_구매하려는_상품아이디와_상품수량_리스트를_전달받아서_주문_생성() throws Exception {
+        // given
+        OrderRequest.CreateOrderRequest orderRequest = new OrderRequest.CreateOrderRequest(
+                1L,
+                List.of(new OrderRequest.OrderItemRequest(testProductId, 2))
+        );
+
+        String requestJson = objectMapper.writeValueAsString(orderRequest);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/orders")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.orderId").exists())
+                .andExpect(jsonPath("$.data.userId").value(1))
+                .andExpect(jsonPath("$.data.status").value("PENDING"))
+                .andExpect(jsonPath("$.data.totalPrice").value(100000))
+                .andExpect(jsonPath("$.data.orderItems").isArray())
+                .andExpect(jsonPath("$.data.orderItems[0].productId").value(testProductId.intValue()))
+                .andExpect(jsonPath("$.data.orderItems[0].quantity").value(2))
+                .andExpect(jsonPath("$.data.orderItems[0].price").value(50000))
+                .andExpect(jsonPath("$.data.orderItems[0].totalPrice").value(100000));
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/interfaces/payment/PaymentControllerConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/interfaces/payment/PaymentControllerConcurrencyTest.java
@@ -97,7 +97,7 @@ public class PaymentControllerConcurrencyTest {
 
     @Test
     @DisplayName("[POST] /api/v1/payments - 동시성 결제 요청 테스트")
-    void concurrentProcessPaymentTest() throws Exception {
+    void 여러스레드_동시_결제_요청() throws Exception {
         // given
         PaymentRequest.PaymentProcessingRequest request = new PaymentRequest.PaymentProcessingRequest(
                 testOrderId,
@@ -143,7 +143,7 @@ public class PaymentControllerConcurrencyTest {
 
     @Test
     @DisplayName("[Concurrent] 결제 및 상품 조회 동시 요청 테스트")
-    void concurrentPaymentAndProductRetrievalTest() throws Exception {
+    void 결제_상품조회_동시_요청시_결제_완료후_감소된_재고가_조회된다() throws Exception {
         int paymentThreadCount = 1;
         int retrievalThreadCount = 5;
         int totalThreads = paymentThreadCount + retrievalThreadCount;

--- a/src/test/java/kr/hhplus/be/server/interfaces/payment/PaymentControllerConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/interfaces/payment/PaymentControllerConcurrencyTest.java
@@ -1,0 +1,210 @@
+package kr.hhplus.be.server.interfaces.payment;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.hhplus.be.server.domain.order.Order;
+import kr.hhplus.be.server.domain.order.OrderLine;
+import kr.hhplus.be.server.domain.point.PointService;
+import kr.hhplus.be.server.domain.product.Product;
+import kr.hhplus.be.server.infra.order.OrderJpaRepository;
+import kr.hhplus.be.server.infra.order.OrderLineJpaRepository;
+import kr.hhplus.be.server.infra.product.ProductJpaRepository;
+import kr.hhplus.be.server.interfaces.dto.payment.request.PaymentRequest;
+import kr.hhplus.be.server.support.constant.PaymentStatus;
+import kr.hhplus.be.server.support.constant.ProductStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class PaymentControllerConcurrencyTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ProductJpaRepository productJpaRepository;
+
+    @Autowired
+    private OrderJpaRepository orderJpaRepository;
+
+    @Autowired
+    private OrderLineJpaRepository orderLineJpaRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private PointService pointService;
+
+    private Long testProductId;
+    private Long testOrderId;
+    private final Long userId = 1L;
+
+
+    @BeforeEach
+    void setUp(){
+        // 데이터베이스 초기화
+        orderLineJpaRepository.deleteAll();
+        orderJpaRepository.deleteAll();
+        productJpaRepository.deleteAll();
+
+        // 테스트 상품 생성
+        Product product = Product.builder()
+                .name("테스트 상품")
+                .price(50000L)
+                .stock(100)
+                .status(ProductStatus.ON_SALE)
+                .build();
+        product = productJpaRepository.save(product);
+        testProductId = product.getProductId();
+
+        // 주문 생성
+        Order order = Order.create(userId);
+        order = orderJpaRepository.save(order);
+        testOrderId = order.getOrderId();
+
+        // 주문 항목 생성
+        OrderLine orderLine = OrderLine.createOrderLine(order.getOrderId(), testProductId, 2, product.getPrice());
+        orderLine = orderLineJpaRepository.save(orderLine);
+
+        // 주문의 총 금액 업데이트
+        order.updateTotalPrice(orderLine.getTotalPrice());
+        orderJpaRepository.save(order);
+
+        // 테스트를 위한 포인트 충전
+        pointService.chargePoint(userId, 1_000_000L);
+    }
+
+    @Test
+    @DisplayName("[POST] /api/v1/payments - 동시성 결제 요청 테스트")
+    void concurrentProcessPaymentTest() throws Exception {
+        // given
+        PaymentRequest.PaymentProcessingRequest request = new PaymentRequest.PaymentProcessingRequest(
+                testOrderId,
+                userId,
+                null  // 쿠폰 사용 없음
+        );
+        String requestJson = objectMapper.writeValueAsString(request);
+
+        int threadCount = 10;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(1);
+
+        List<Future<Integer>> futures = new ArrayList<>();
+
+        // 여러 스레드가 동시에 결제 요청 보내도록
+        for (int i = 0; i < threadCount; i++) {
+            futures.add(executor.submit(() -> {
+                latch.await();
+                MvcResult result = mockMvc.perform(post("/api/v1/payments")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(requestJson))
+                        .andReturn();
+                return result.getResponse().getStatus();
+            }));
+        }
+
+        latch.countDown();
+        executor.shutdown();
+        executor.awaitTermination(30, TimeUnit.SECONDS);
+
+        int successCount = 0;
+        int failureCount = 0;
+        for (Future<Integer> future : futures) {
+            int status = future.get();
+            if (status == 200) {
+                successCount++;
+            } else {
+                failureCount++;
+            }
+        }
+        assertThat(successCount).isEqualTo(threadCount);
+    }
+
+    @Test
+    @DisplayName("[Concurrent] 결제 및 상품 조회 동시 요청 테스트")
+    void concurrentPaymentAndProductRetrievalTest() throws Exception {
+        int paymentThreadCount = 1;
+        int retrievalThreadCount = 5;
+        int totalThreads = paymentThreadCount + retrievalThreadCount;
+        ExecutorService executor = Executors.newFixedThreadPool(totalThreads);
+        CountDownLatch latch = new CountDownLatch(1);
+
+        // 결제 요청 DTO 및 JSON 준비
+        PaymentRequest.PaymentProcessingRequest paymentRequest = new PaymentRequest.PaymentProcessingRequest(
+                testOrderId,
+                userId,
+                null  // 쿠폰 미사용
+        );
+        String paymentRequestJson = objectMapper.writeValueAsString(paymentRequest);
+
+        List<Future<Integer>> paymentFutures = new ArrayList<>();
+        List<Future<Integer>> retrievalFutures = new ArrayList<>();
+
+        // 결제 요청 스레드 제출
+        for (int i = 0; i < paymentThreadCount; i++) {
+            paymentFutures.add(executor.submit(() -> {
+                latch.await();  // 모든 스레드가 동시에 시작하도록 대기
+                MvcResult result = mockMvc.perform(post("/api/v1/payments")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(paymentRequestJson))
+                        .andReturn();
+                return result.getResponse().getStatus();
+            }));
+        }
+
+        // 상품 조회 요청 스레드 제출
+        for (int i = 0; i < retrievalThreadCount; i++) {
+            retrievalFutures.add(executor.submit(() -> {
+                latch.await();
+                MvcResult result = mockMvc.perform(get("/api/v1/products/{productId}", testProductId))
+                        .andReturn();
+                return result.getResponse().getStatus();
+            }));
+        }
+
+        latch.countDown();
+        executor.shutdown();
+        executor.awaitTermination(30, TimeUnit.SECONDS);
+
+        // 결제 요청 결과
+        int successCount = 0;
+        for (Future<Integer> future : paymentFutures) {
+            int status = future.get();
+            if (status == 200) successCount++;
+        }
+
+        // 상품 조회 요청 결과
+        for (Future<Integer> future : retrievalFutures) {
+            int status = future.get();
+            if(status != 200) {
+                fail("상품 조회 요청 실패");
+            }
+        }
+
+        // when & then
+        mockMvc.perform(get("/api/v1/products/{productId}", testProductId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.stock").value(98));
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/interfaces/payment/PaymentControllerIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/interfaces/payment/PaymentControllerIntegrationTest.java
@@ -1,0 +1,107 @@
+package kr.hhplus.be.server.interfaces.payment;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.hhplus.be.server.domain.order.Order;
+import kr.hhplus.be.server.domain.order.OrderLine;
+import kr.hhplus.be.server.domain.product.Product;
+import kr.hhplus.be.server.infra.order.OrderJpaRepository;
+import kr.hhplus.be.server.infra.order.OrderLineJpaRepository;
+import kr.hhplus.be.server.infra.product.ProductJpaRepository;
+import kr.hhplus.be.server.interfaces.dto.order.request.OrderRequest;
+import kr.hhplus.be.server.interfaces.dto.payment.request.PaymentRequest;
+import kr.hhplus.be.server.support.constant.ProductStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class PaymentControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ProductJpaRepository productJpaRepository;
+
+    @Autowired
+    private OrderJpaRepository orderJpaRepository;
+
+    @Autowired
+    private OrderLineJpaRepository orderLineJpaRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private Long testProductId;
+    private Long testOrderId;
+    private final Long userId = 1L;
+
+    @BeforeEach
+    void setUp(){
+        // 데이터베이스 초기화
+        orderLineJpaRepository.deleteAll();
+        orderJpaRepository.deleteAll();
+        productJpaRepository.deleteAll();
+
+        // 테스트 상품 생성
+        Product product = Product.builder()
+                .name("테스트 상품")
+                .price(50000L)
+                .stock(100)
+                .status(ProductStatus.ON_SALE)
+                .build();
+        product = productJpaRepository.save(product);
+        testProductId = product.getProductId();
+
+        // 주문 생성
+        Order order = Order.create(userId);
+        order = orderJpaRepository.save(order);
+        testOrderId = order.getOrderId();
+
+        // 주문 항목 생성
+        OrderLine orderLine = OrderLine.createOrderLine(order.getOrderId(), testProductId, 2, product.getPrice());
+        orderLine = orderLineJpaRepository.save(orderLine);
+
+        // 주문의 총 금액 업데이트
+        order.updateTotalPrice(orderLine.getTotalPrice());
+        orderJpaRepository.save(order);
+    }
+
+    @Test
+    @DisplayName("[POST] /api/v1/payments - 결제 처리 테스트")
+    void 사용자아이디와_주문아이디를_전달받아서_결제_처리_성공() throws Exception {
+        // given
+        PaymentRequest.PaymentProcessingRequest request = new PaymentRequest.PaymentProcessingRequest(
+                testOrderId,
+                userId,
+                null
+        );
+        String requestJson = objectMapper.writeValueAsString(request);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/payments")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.paymentId").exists())
+                .andExpect(jsonPath("$.data.orderId").value(testOrderId.intValue()))
+                .andExpect(jsonPath("$.data.userId").value(userId.intValue()))
+                .andExpect(jsonPath("$.data.status").exists())
+                .andExpect(jsonPath("$.data.totalAmount").value(100000))
+                .andExpect(jsonPath("$.data.finalAmount").value(100000))
+                .andExpect(jsonPath("$.data.remainingPoints").exists());
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/interfaces/point/PointControllerConcurrencyIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/interfaces/point/PointControllerConcurrencyIntegrationTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import static org.assertj.core.api.Assertions.assertThat;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;

--- a/src/test/java/kr/hhplus/be/server/interfaces/point/PointControllerConcurrencyIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/interfaces/point/PointControllerConcurrencyIntegrationTest.java
@@ -1,0 +1,112 @@
+package kr.hhplus.be.server.interfaces.point;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.hhplus.be.server.domain.point.Point;
+import kr.hhplus.be.server.domain.user.User;
+import kr.hhplus.be.server.infra.point.PointJpaRepository;
+import kr.hhplus.be.server.infra.user.UserJpaRepository;
+import kr.hhplus.be.server.interfaces.dto.point.request.PointChargeRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.concurrent.*;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class PointControllerConcurrencyIntegrationTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserJpaRepository userJpaRepository;
+
+    @Autowired
+    private PointJpaRepository pointJpaRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private Long testUserId;
+
+    @BeforeEach
+    void setUp(){
+        // 데이터베이스 초기화
+        pointJpaRepository.deleteAll();
+        userJpaRepository.deleteAll();
+
+        // 테스트 사용자 생성
+        User user = User.builder()
+                .userId(null)
+                .name("설한정")
+                .build();
+        user = userJpaRepository.save(user);
+        testUserId = user.getUserId();
+
+        // 사용자 초기 포인트
+        Point point = Point.builder()
+                .userId(testUserId)
+                .balance(0L)
+                .build();
+        pointJpaRepository.save(point);
+    }
+
+    @Test
+    @DisplayName("동시성 테스트 - 사용자의 충전과 조회 요청")
+    void 충전과_조회가_동시에_요청되면_충전된_금액이_조회된다() throws Exception{
+        int iterations = 100;
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch latch = new CountDownLatch(1);
+
+        for(int i = 0; i<iterations; i++) {
+
+
+            // 여러개의 충전 대기
+            Callable<Void> chargeTask = () -> {
+                latch.await(); // 동시 시작을 위한 대기 설정
+                var chargeRequest = new PointChargeRequest(testUserId, 1000L);
+                String requestJson = objectMapper.writeValueAsString(chargeRequest);
+                mockMvc.perform(post("/api/v1/points/charge")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(requestJson))
+                        .andExpect(status().isOk());
+                return null;
+            };
+
+            // 조회 작업 정의
+            Callable<String> getTask = () -> {
+                latch.await();
+                return mockMvc.perform(get("/api/v1/points/{userId}", testUserId))
+                        .andExpect(status().isOk())
+                        .andReturn().getResponse().getContentAsString();
+            };
+
+            // 두 작업을 ExecutorService에 제출
+            Future<Void> chargeFuture = executor.submit(chargeTask);
+            Future<String> getFuture = executor.submit(getTask);
+
+            latch.countDown();  // latch.await()으로 대기시킨 작업 돋시 실행
+            chargeFuture.get(); // 충전 작업 완료 결과
+            String getResponse = getFuture.get(); // 조회 작업 결과 획득 (동시성 요청 중의 조회)
+        }
+
+        // 최종 잔액 조회 및 검증
+        mockMvc.perform(get("/api/v1/points/{userId}", testUserId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.balance").value(100*1000L));
+
+        executor.shutdown();  // ExecutorService 종료
+
+    }
+
+}

--- a/src/test/java/kr/hhplus/be/server/interfaces/point/PointControllerIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/interfaces/point/PointControllerIntegrationTest.java
@@ -1,0 +1,104 @@
+package kr.hhplus.be.server.interfaces.point;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.hhplus.be.server.domain.point.Point;
+import kr.hhplus.be.server.domain.user.User;
+import kr.hhplus.be.server.infra.point.PointJpaRepository;
+import kr.hhplus.be.server.infra.user.UserJpaRepository;
+import kr.hhplus.be.server.interfaces.dto.point.request.PointChargeRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class PointControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserJpaRepository userJpaRepository;
+
+    @Autowired
+    private PointJpaRepository pointJpaRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private Long testUserId;
+
+    @BeforeEach
+    void setUp(){
+        // 데이터베이스 초기화
+        pointJpaRepository.deleteAll();
+        userJpaRepository.deleteAll();
+
+        // 테스트 사용자 생성
+        User user = User.builder()
+                .userId(null)
+                .name("설한정")
+                .build();
+        user = userJpaRepository.save(user);
+        testUserId = user.getUserId();
+
+        // 사용자 초기 포인트
+        Point point = Point.builder()
+                .userId(testUserId)
+                .balance(0L)
+                .build();
+        pointJpaRepository.save(point);
+    }
+
+    @Test
+    @DisplayName("[POST] /api/v1/points/charge - 포인트 충전 성공 테스트")
+    void userId와_amount_50000을_전달하면_충전_성공() throws Exception{
+        // given
+        var chargeRequest = new PointChargeRequest(
+                testUserId,
+                50000L
+        );
+
+        String requestJson = objectMapper.writeValueAsString(chargeRequest);
+
+        // when
+        var response = mockMvc.perform(post("/api/v1/points/charge")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson));
+        // then
+        response.andExpect(status().isOk())
+                // API 응답 검증 : 성공 코드 및 응답 데이터 확인
+                .andExpect(jsonPath("$.data.userId").value(testUserId.intValue()))
+                .andExpect(jsonPath("$.data.chargedAmount").value(50000));
+    }
+
+    @Test
+    @DisplayName("[GET] /api/v1/points/{userId} - 사용자 포인트 조회 성공 테스트")
+    void userId가_전달되면_해당_사용자의_포인트_조회에_성공() throws Exception{
+        // given
+        var chargeRequest = new PointChargeRequest(testUserId, 50000L);
+        String requestJson = objectMapper.writeValueAsString(chargeRequest);
+
+        mockMvc.perform(post("/api/v1/points/charge")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isOk());
+
+        // When & Then: 포인트 조회 요청 및 검증
+        mockMvc.perform(get("/api/v1/points/{userId}", testUserId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.userId").value(testUserId.intValue()))
+                .andExpect(jsonPath("$.data.balance").value(50000));
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/interfaces/product/ProductControllerIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/interfaces/product/ProductControllerIntegrationTest.java
@@ -1,0 +1,91 @@
+package kr.hhplus.be.server.interfaces.product;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.hhplus.be.server.domain.product.Product;
+import kr.hhplus.be.server.infra.order.OrderJpaRepository;
+import kr.hhplus.be.server.infra.order.OrderLineJpaRepository;
+import kr.hhplus.be.server.infra.product.ProductJpaRepository;
+import kr.hhplus.be.server.interfaces.dto.product.request.ProductRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+@SpringBootTest
+@AutoConfigureMockMvc
+public class ProductControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ProductJpaRepository productJpaRepository;
+
+    @Autowired
+    private OrderJpaRepository orderJpaRepository;
+
+    @Autowired
+    private OrderLineJpaRepository orderLineJpaRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp(){
+        // 데이터베이스 초기화
+        productJpaRepository.deleteAll();
+        orderJpaRepository.deleteAll();
+        orderLineJpaRepository.deleteAll();
+
+        // 테스트 상품 생성 -> 20개 생성 후 리스트 확인
+        for (int i = 1; i <= 20; i++) {
+            Product product = Product.builder()
+                    .name("상품" + i)
+                    .price(10000L * i)
+                    .stock(100 + i)
+                    .status(kr.hhplus.be.server.support.constant.ProductStatus.ON_SALE)
+                    .build();
+            productJpaRepository.save(product);
+        }
+    }
+
+    @Test
+    @DisplayName("[GET] /api/v1/products - 페이징 처리된 상품 목록 조회 테스트")
+    void 페이징_처리된_상품_목록_조회_성공() throws Exception{
+        // given
+        ProductRequest.ProductInfoRequest request = new ProductRequest.ProductInfoRequest(0, 10);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/products")
+                        .param("page", String.valueOf(request.page()))
+                        .param("size", String.valueOf(request.size())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content").isArray())
+                .andExpect(jsonPath("$.data.content.length()").value(10))
+                .andExpect(jsonPath("$.data.content[0].productId").exists())
+                .andExpect(jsonPath("$.data.content[0].name").exists());
+    }
+
+    @Test
+    @DisplayName("[GET] /api/v1/products/{productId} - 상품 상세 조회 테스트")
+    void 상품_상세_조회_성공() throws Exception {
+        // given
+        Product existingProduct = productJpaRepository.findAll(PageRequest.of(0, 1)).getContent().get(0);
+        Long productId = existingProduct.getProductId();
+
+        // when & then
+        mockMvc.perform(get("/api/v1/products/{productId}", productId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.productId").value(productId.intValue()))
+                .andExpect(jsonPath("$.data.name").value(existingProduct.getName()))
+                .andExpect(jsonPath("$.data.price").value(existingProduct.getPrice()))
+                .andExpect(jsonPath("$.data.stock").value(existingProduct.getStock()));
+    }
+}


### PR DESCRIPTION
### **5주차 진행 내용**
1. Service나 Facade가 이미 검증된 상황에서, 통합 테스트를 해당 계층에서 진행하면 Controller에서 필드가 변경되었을 때 발생할 수 있는 문제를 확인하기 어렵다는 피드백을 반영했습니다. 따라서 이번 주차에는 통합 테스트를 Controller 계층에서 진행했습니다.
2. SQL문을 사용한 테스트는 필드 추가 시 build 메서드와 달리 값이 null인지 판단하기 어렵다는 피드백을 반영했습니다. 이를 보완하기 위해 `@BeforeEach`를 활용하여 테스트 데이터 값을 코드 내에서 명시적으로 정의했습니다.

### **커밋 링크**
- PointController 통합 테스트 : 323094396e4b779bdf40701566163835bb67a983
- CouponController 통합 테스트 : b730500352ef60849e3081a69f6102c11d4da04d
- ProductController 통합 테스트 : d1b0fcdb2a03b39c9187a14ede65d2255e2ca062
- OrderController 통합 테스트 : 91c56051660bc7ff69e7e335cee701d87507ca59
- PaymentController 통합 테스트 : d1e878e661b72955d4fef40595dc04a4f29d0600
- 회고록 : [2챕터 회고록](https://vanilla-pen-0ee.notion.site/2-17ee9d02ef3a80679f1ff86dd5c64b24?pvs=4)
<!-- 
좋은 피드백을 받기 위해 가장 중요한 것은 코드를 작성할 때 커밋을 작업 단위로 잘 쪼개는 것입니다.
모든 작업을 하나의 커밋에 진행하고 PR을 하면 구조 파악에 많은 시간을 소모하기 때문에 절대로
좋은 피드백을 받을 수 없습니다.


필수 양식)
커밋 이름 : 커밋 링크

예시)
동시성 처리 : c83845
동시성 테스트 코드 : d93ji3
-->

---
### **리뷰 포인트(질문)**
- `@BeforeEach`를 사용해 테스트 데이터를 명시적으로 정의했는데 코드가 너무 길어지는 부분이 발생 하는 것 같아서 이 방식이 최선인지 모르겠습니다. 특정 도메인 컨트롤러의 엔드포인트들에 대해서 테스트 데이터가 많아지거나 복잡해질 경우 다른 대안이 있는지, 아니면 테스트 데이터를 관리하는 다른 패턴이 있을지 궁금합니다.
<!-- - 리뷰어가 특히 확인해야 할 부분이나 신경 써야 할 코드가 있다면 명확히 작성해주세요.(최대 2개)
  
  좋은 예:
  - `ErrorMessage` 컴포넌트의 상태 업데이트 로직이 적절한지 검토 부탁드립니다.
  - 추가한 유닛 테스트(`LoginError.test.js`)의 테스트 케이스가 충분한지 확인 부탁드립니다.

  나쁜 예:
  - 개선사항을 알려주세요.
  - 코드 전반적으로 봐주세요.
  - 뭘 질문할지 모르겠어요. -->
---
