### PR TITLE
[STEP-13 , STEP-14] 레디스 캐시 활용 로직 이관 보고서 및 쿠폰 발급·인기 상품 조회 캐시 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ out/
 .vscode/
 
 data
+
+### Log files ###
+*.log
+logs/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,6 +50,9 @@ dependencies {
 	annotationProcessor("jakarta.persistence:jakarta.persistence-api")
 	// queryDsl 끝
 
+	// redis & redisson 의존성 추가_Week07
+	implementation("org.springframework.boot:spring-boot-starter-data-redis")
+	implementation("org.redisson:redisson-spring-boot-starter:3.27.0")
 
 	// Test
     testImplementation("org.springframework.boot:spring-boot-starter-test")
@@ -57,6 +60,10 @@ dependencies {
 	testImplementation("org.testcontainers:junit-jupiter")
 	testImplementation("org.testcontainers:mysql")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+	// 테스트 코드 lombok 의존성 추가_Week07
+	testCompileOnly("org.projectlombok:lombok:1.18.22")
+	testAnnotationProcessor("org.projectlombok:lombok")
 }
 
 tasks.withType<Test> {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,12 @@ services:
     volumes:
       - ./data/mysql/:/var/lib/mysql
 
+  redis:
+    image: redis:7.0
+    ports:
+      - "6379:6379"
+    volumes:
+      - ./data/redis:/data
 networks:
   default:
     driver: bridge

--- a/src/main/java/kr/hhplus/be/server/ServerApplication.java
+++ b/src/main/java/kr/hhplus/be/server/ServerApplication.java
@@ -2,8 +2,10 @@ package kr.hhplus.be.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class ServerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/kr/hhplus/be/server/application/coupon/CouponFacade.java
+++ b/src/main/java/kr/hhplus/be/server/application/coupon/CouponFacade.java
@@ -6,6 +6,7 @@ import kr.hhplus.be.server.application.coupon.response.CouponResult;
 import kr.hhplus.be.server.domain.coupon.CouponService;
 import kr.hhplus.be.server.domain.coupon.dto.CouponInfo;
 import kr.hhplus.be.server.domain.user.UserService;
+import kr.hhplus.be.server.support.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -40,6 +41,20 @@ public class CouponFacade {
         return userCouponList.stream()
                 .map(CouponResult.UserCouponResult::from)
                 .toList();
+    }
+
+    /**
+     * Redis를 사용한 비동기 쿠폰 발급 요청
+     */
+    public CouponResult.IssueRequestResult requestCouponIssue(CouponCommand.IssueCoupon command) {
+        userService.getUserById(command.userId());
+
+        try {
+            couponService.requestCouponIssue(command.userId(), command.couponId());
+            return CouponResult.IssueRequestResult.of("쿠폰 발급이 요청되었습니다.");
+        } catch (BusinessException e) {
+            return CouponResult.IssueRequestResult.of(e.getMessage());
+        }
     }
 
 }

--- a/src/main/java/kr/hhplus/be/server/application/coupon/response/CouponResult.java
+++ b/src/main/java/kr/hhplus/be/server/application/coupon/response/CouponResult.java
@@ -47,4 +47,15 @@ public class CouponResult {
             );
         }
     }
+
+    /**
+     * 비동기 쿠폰 발급 요청 결과
+     */
+    public record IssueRequestResult(
+            String message
+    ) {
+        public static IssueRequestResult of(String message) {
+            return new IssueRequestResult(message);
+        }
+    }
 }

--- a/src/main/java/kr/hhplus/be/server/application/product/ProductFacade.java
+++ b/src/main/java/kr/hhplus/be/server/application/product/ProductFacade.java
@@ -18,7 +18,7 @@ public class ProductFacade {
     /**
      * 페이징 처리된 상품 목록 리스트
      */
-    public Page<ProductResult.ProductInfoResult> getProductPage(ProductCommand.GetProductList command){
+    public Page<ProductResult.ProductInfoResult> getProductPage(ProductCommand.GetProductList command) {
         return productService.getAllProductPage(command.page(), command.size())
                 .map(ProductResult.ProductInfoResult::from);
     }
@@ -26,15 +26,23 @@ public class ProductFacade {
     /**
      * 단일 상품 상세 정보 조히
      */
-    public ProductResult.ProductInfoResult getProduct(ProductCommand.GetProduct command){
+    public ProductResult.ProductInfoResult getProduct(ProductCommand.GetProduct command) {
         return ProductResult.ProductInfoResult
                 .from(productService.getProductByIdWithLock(command.productId()));
     }
 
-    public List<ProductResult.ProductPopularResult> getProductPopularList(){
+    public List<ProductResult.ProductPopularResult> getProductPopularList() {
         return productService.getPopularProducts().stream()
                 .map(ProductResult.ProductPopularResult::from)
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * 레디스 캐시를 활용한 인기 상품 조회
+     */
+    public List<ProductResult.ProductPopularResult> getProductPopularListByRedis() {
+        return productService.getPopularProductsByRedis();
+
     }
 
 }

--- a/src/main/java/kr/hhplus/be/server/config/redis/RedisConfig.java
+++ b/src/main/java/kr/hhplus/be/server/config/redis/RedisConfig.java
@@ -1,0 +1,38 @@
+package kr.hhplus.be.server.config.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableCaching
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory(){
+        RedisStandaloneConfiguration redisConfig = new RedisStandaloneConfiguration(redisHost, redisPort);
+        return new LettuceConnectionFactory(redisConfig);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(){
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return template;
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/config/redis/RedisConfig.java
+++ b/src/main/java/kr/hhplus/be/server/config/redis/RedisConfig.java
@@ -35,4 +35,17 @@ public class RedisConfig {
         template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
         return template;
     }
+
+    /**
+     * 재고 감소 시 순자 연산이 필요한 경우 사용 -> 기존 Jackson 직렬화 사용으로 인한 decrease() 문제 해결
+     * 모든 값에 대해 String 직렬화 진행
+     */
+    @Bean("redisNumericTemplate")
+    public RedisTemplate<String, String> redisNumericTemplate(){
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        return template;
+    }
 }

--- a/src/main/java/kr/hhplus/be/server/domain/coupon/CouponCacheRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/coupon/CouponCacheRepository.java
@@ -1,0 +1,30 @@
+package kr.hhplus.be.server.domain.coupon;
+
+import kr.hhplus.be.server.domain.coupon.dto.CouponIssueRequest;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+public interface CouponCacheRepository {
+
+    // 쿠폰 발급 요청 관련
+    void addCouponRequest(Long couponId, Long userId, long timestamp);
+    List<CouponIssueRequest> getPendingRequests(Long couponId, int count);
+    void removeFromRequestQueue(Long couponId, Long userId);
+
+    // 발급 상태 관리
+    boolean hasIssuedCoupon(Long couponId, Long userId);
+    void markAsIssued(Long couponId, Long userId);
+    void markAsFailed(Long couponId, Long userId);
+
+    // 쿠폰 재고 관리
+    Optional<Integer> getStockCache(Long couponId);
+    void setStockCache(Long couponId, int stock);
+
+    void incrementStock(Long couponId);
+    boolean decrementStock(Long couponId);
+    Set<String> findActiveCouponKeys();
+
+}
+

--- a/src/main/java/kr/hhplus/be/server/domain/coupon/dto/CouponIssueRequest.java
+++ b/src/main/java/kr/hhplus/be/server/domain/coupon/dto/CouponIssueRequest.java
@@ -1,0 +1,10 @@
+package kr.hhplus.be.server.domain.coupon.dto;
+
+import lombok.Value;
+
+@Value
+public class CouponIssueRequest{
+    Long couponId;
+    Long userId;
+    long timestamp;
+}

--- a/src/main/java/kr/hhplus/be/server/domain/product/ProductCacheRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/product/ProductCacheRepository.java
@@ -1,0 +1,12 @@
+package kr.hhplus.be.server.domain.product;
+
+import kr.hhplus.be.server.application.product.response.ProductResult;
+import kr.hhplus.be.server.domain.product.dto.ProductInfo;
+
+import java.util.List;
+
+public interface ProductCacheRepository {
+    void savePopularProducts(List<ProductResult.ProductPopularResult> products);
+
+    List<ProductResult.ProductPopularResult> getPopularProducts();
+}

--- a/src/main/java/kr/hhplus/be/server/domain/product/ProductService.java
+++ b/src/main/java/kr/hhplus/be/server/domain/product/ProductService.java
@@ -1,9 +1,11 @@
 package kr.hhplus.be.server.domain.product;
 
+import kr.hhplus.be.server.application.product.response.ProductResult;
 import kr.hhplus.be.server.domain.product.dto.ProductInfo;
 import kr.hhplus.be.server.support.constant.ErrorCode;
 import kr.hhplus.be.server.support.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -11,14 +13,17 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class ProductService {
     private final ProductRepository productRepository;
+    private final ProductCacheRepository productCacheRepository;
 
     @Transactional
     public List<Product> getAllProducts() {
@@ -79,12 +84,40 @@ public class ProductService {
     public List<ProductInfo.ProductPopularList> getPopularProducts() {
         List<ProductInfo.ProductPopularQueryDto> queryResults = productRepository.findPopularProducts();
 
+
+        // 인기상품이 존재하지 않는 경우 빈 리스트 반환하도록 수정
         if(queryResults.isEmpty()){
-            throw new BusinessException(ErrorCode.PRODUCT_NOT_FOUND);
+            log.info("인기 상품이 존재하지 않습니다.");
+            return Collections.emptyList();
         }
+//        if(queryResults.isEmpty()){
+//            throw new BusinessException(ErrorCode.PRODUCT_NOT_FOUND);
+//        }
 
         return IntStream.range(0, queryResults.size())
                 .mapToObj(i -> ProductInfo.ProductPopularList.from(queryResults.get(i), i + 1))
                 .collect(Collectors.toList());
+    }
+
+    public List<ProductResult.ProductPopularResult> getPopularProductsByRedis(){
+        // 1. 캐시에서 조회
+        List<ProductResult.ProductPopularResult> cachedProducts = productCacheRepository.getPopularProducts();
+
+        if(!cachedProducts.isEmpty()){
+            return cachedProducts;
+        }
+
+        // 2. 데이터베이스 조회
+        // DB에서 조회, 빈 리스트여도 캐시에 저장
+        List<ProductResult.ProductPopularResult> products =
+                getPopularProducts().stream()
+                        .map(ProductResult.ProductPopularResult::from)
+                        .collect(Collectors.toList());
+
+        // 캐시 미스 방지 -> 빈 리스트도 캐시에 저장되도록
+        productCacheRepository.savePopularProducts(products);
+
+        return products;
+
     }
 }

--- a/src/main/java/kr/hhplus/be/server/infra/coupon/CouponCacheRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/infra/coupon/CouponCacheRepositoryImpl.java
@@ -1,0 +1,164 @@
+package kr.hhplus.be.server.infra.coupon;
+
+import kr.hhplus.be.server.domain.coupon.CouponCacheRepository;
+import kr.hhplus.be.server.domain.coupon.dto.CouponIssueRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CouponCacheRepositoryImpl implements CouponCacheRepository {
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    // 숫자 연산 및 재고 관련 작업에 사용할 템플릿
+    @Qualifier("redisNumericTemplate")
+    private final RedisTemplate<String, String> redisNumericTemplate;
+    // 쿠폰 요청 큐
+    private static final String KEY_COUPON_REQUESTS = "coupon:%d:requests";
+    // 발급 완료된 쿠폰 목록
+    private static final String KEY_COUPON_ISSUED = "coupon:%d:issued";
+    // 발급 실패한 쿠폰 목록
+    private static final String KEY_COUPON_FAILED = "coupon:%d:failed";
+    // 쿠폰 재고 정보
+    private static final String KEY_COUPON_STOCK = "coupon:%d:stock";
+    // TTL 1시간 설정
+    private static final long CACHE_TTL = 60 * 60;
+
+    /**
+     * 쿠폰 요청 시 Redis 정렬 ZSet 추가
+     * key값ㅂ으로 couponId, userId
+     * score로 timestamp 사용
+     */
+    @Override
+    public void addCouponRequest(Long couponId, Long userId, long timestamp) {
+        String requestKey = String.format(KEY_COUPON_REQUESTS, couponId);
+        redisTemplate.opsForZSet().add(requestKey, String.valueOf(userId), timestamp);
+    }
+
+    /**
+     * 대기중인 쿠폰 발급 요청 조회
+     */
+    @Override
+    public List<CouponIssueRequest> getPendingRequests(Long couponId, int count) {
+        String requestKey = String.format(KEY_COUPON_REQUESTS, couponId);
+        // Redis ZSet에서 요청된 사용자 아이디와 타임스탬프 조회 , 타임스탬프를 score로 사용 중
+        Set<ZSetOperations.TypedTuple<Object>> tuples =
+                redisTemplate.opsForZSet().rangeWithScores(requestKey, 0, count - 1);
+        // 조회한 데이터를 CouponIssueRequest 객체 리스트로 변환
+        return tuples.stream()
+                .map(tuple -> new CouponIssueRequest(
+                        couponId,
+                        Long.parseLong(String.valueOf(tuple.getValue())),
+                        tuple.getScore().longValue()))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 쿠폰 요청 큐에서 특정 사용자의 요청 제거
+     */
+    @Override
+    public void removeFromRequestQueue(Long couponId, Long userId) {
+        String requestKey = String.format(KEY_COUPON_REQUESTS, couponId);
+        redisTemplate.opsForZSet().remove(requestKey, String.valueOf(userId));
+    }
+
+    /**
+     * 사용자가 쿠폰을 발급받았는지 확인
+     */
+    @Override
+    public boolean hasIssuedCoupon(Long couponId, Long userId) {
+        String issuedKey = String.format(KEY_COUPON_ISSUED, couponId);
+        Boolean isMember = redisTemplate.opsForSet().isMember(issuedKey, String.valueOf(userId));
+        return Boolean.TRUE.equals(isMember);
+    }
+
+    /**
+     * 사용자를 발급 완료된 쿠폰 목록에 추가
+     */
+    @Override
+    public void markAsIssued(Long couponId, Long userId) {
+        String issuedKey = String.format(KEY_COUPON_ISSUED, couponId);
+        redisTemplate.opsForSet().add(issuedKey, userId);
+    }
+
+    /**
+     * 사용자를 발급 실패 목록에 추가
+     */
+    @Override
+    public void markAsFailed(Long couponId, Long userId) {
+        String failedKey = String.format(KEY_COUPON_FAILED, couponId);
+        redisTemplate.opsForSet().add(failedKey, userId);
+    }
+
+    /**
+     * 쿠폰 재고를 조회
+     */
+    @Override
+    public Optional<Integer> getStockCache(Long couponId) {
+        String stockKey = String.format(KEY_COUPON_STOCK, couponId);
+        String value = redisNumericTemplate.opsForValue().get(stockKey);
+        if (value == null) return Optional.empty();
+        try {
+            return Optional.of(Integer.parseInt(value));
+        } catch (NumberFormatException e) {
+            log.error("재고 값 조회 실패. 키 : {}: {}", stockKey, value);
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * 쿠폰 재고를 캐시에 추가
+     */
+    @Override
+    public void setStockCache(Long couponId, int stock) {
+        String stockKey = String.format(KEY_COUPON_STOCK, couponId);
+        redisNumericTemplate.opsForValue().set(stockKey, String.valueOf(stock), CACHE_TTL, TimeUnit.SECONDS);
+
+    }
+
+    /**
+     * 쿠폰 재고 증가, 발급 실패 시 복원 용도
+     */
+    @Override
+    public void incrementStock(Long couponId) {
+        String stockKey = String.format(KEY_COUPON_STOCK, couponId);
+        redisNumericTemplate.opsForValue().increment(stockKey);
+    }
+
+    /**
+     * 쿠폰 재고 감소
+     */
+    @Override
+    public boolean decrementStock(Long couponId) {
+        String stockKey = String.format(KEY_COUPON_STOCK, couponId);
+        // 먼저 키 존재 여부 확인
+        if (!Boolean.TRUE.equals(redisNumericTemplate.hasKey(stockKey))) {
+            // 키가 없으면 재고 캐시가 초기화되지 않은 상태로 판단하여 false 반환
+            return false;
+        }
+        Long currentStock = redisNumericTemplate.opsForValue()
+                .decrement(stockKey);
+        return currentStock != null && currentStock >= 0;
+    }
+
+    /**
+     * 쿠폰 발급 요청 키 목록 반환
+     */
+    @Override
+    public Set<String> findActiveCouponKeys() {
+        // 요청 큐에 해당하는 모든 키 반환
+        Set<String> keys = redisTemplate.keys("coupon:*:requests");
+        return keys != null ? keys : Collections.emptySet();
+    }}

--- a/src/main/java/kr/hhplus/be/server/infra/product/ProductCacheRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/infra/product/ProductCacheRepositoryImpl.java
@@ -37,7 +37,7 @@ public class ProductCacheRepositoryImpl implements ProductCacheRepository {
                         CACHE_TTL,
                         TimeUnit.SECONDS
                 );
-                log.info("인기상품 목록이 없습니다.");s
+                log.info("인기상품 목록이 없습니다.");
                 return;
             }
 

--- a/src/main/java/kr/hhplus/be/server/infra/product/ProductCacheRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/infra/product/ProductCacheRepositoryImpl.java
@@ -1,0 +1,88 @@
+package kr.hhplus.be.server.infra.product;
+
+import kr.hhplus.be.server.application.product.response.ProductResult;
+import kr.hhplus.be.server.domain.product.ProductCacheRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ProductCacheRepositoryImpl implements ProductCacheRepository {
+    private final RedisTemplate<String, Object> redisTemplate;
+    private static final String KEY_POPULAR_PRODUCTS = "popular:products";
+    // 인기상품 목록 캐시 24시간 유효 설정
+    private static final long CACHE_TTL = 24 * 60 * 60; // 24시간
+
+
+    @Override
+    public void savePopularProducts(List<ProductResult.ProductPopularResult> products){
+        try {
+            // 기존 데이터 삭제
+            redisTemplate.delete(KEY_POPULAR_PRODUCTS);
+
+            // 빈 리스트라도 저장 (인기상풍 목록 없음 처리)
+            if (products.isEmpty()) {
+                redisTemplate.opsForValue().set(
+                        KEY_POPULAR_PRODUCTS + ":empty",
+                        "empty",
+                        CACHE_TTL,
+                        TimeUnit.SECONDS
+                );
+                log.info("인기상품 목록이 없습니다.");s
+                return;
+            }
+
+            // 데이터가 있는 경우 정상 저장
+            for (int i = 0; i < products.size(); i++) {
+                redisTemplate.opsForZSet().add(
+                        KEY_POPULAR_PRODUCTS,
+                        products.get(i),
+                        products.size() - i
+                );
+            }
+
+            // TTL 설정 -> 24시간
+            redisTemplate.expire(KEY_POPULAR_PRODUCTS, CACHE_TTL, TimeUnit.SECONDS);
+            log.info("인기상품 목록 캐시 크기: {}", products.size());
+
+        } catch (Exception e) {
+            log.error("인기상품 목록 캐시 저장 실패", e);
+        }
+    }
+    @Override
+    public List<ProductResult.ProductPopularResult> getPopularProducts(){
+        try {
+            // 빈 리스트 표시 확인
+            Boolean isEmpty = redisTemplate.hasKey(KEY_POPULAR_PRODUCTS + ":empty");
+            if (Boolean.TRUE.equals(isEmpty)) {
+                log.info("인기상품 목록 비어있음.");
+                return Collections.emptyList();
+            }
+
+            // 정상 데이터 조회
+            Set<Object> products = redisTemplate.opsForZSet()
+                    .reverseRange(KEY_POPULAR_PRODUCTS, 0, 4);  // top 5
+
+            if (products == null || products.isEmpty()) {
+                return Collections.emptyList();
+            }
+
+            return products.stream()
+                    .map(p -> (ProductResult.ProductPopularResult) p)
+                    .collect(Collectors.toList());
+
+        } catch (Exception e) {
+            log.error("인기상품 캐시 조회 실패", e);
+            return Collections.emptyList();
+        }
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/interfaces/api/coupon/CouponController.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/api/coupon/CouponController.java
@@ -50,4 +50,16 @@ public class CouponController {
 
         return ResponseEntity.ok(CustomApiResponse.of(SuccessCode.COUPONS_FOUND, response));
     }
+
+    @Operation(summary = "쿠폰 발급 요청", description = "비동기 쿠폰 발급 요청")
+    @PostMapping("/issue/async")
+    public ResponseEntity<CustomApiResponse<CouponResponse.IssueRequestResponse>> requestIssueCoupon(
+            @RequestBody CouponRequest.IssueRequest request) {
+        CouponResult.IssueRequestResult result =
+                couponFacade.requestCouponIssue(CouponCommand.IssueCoupon.from(request));
+        return ResponseEntity.ok(CustomApiResponse.of(
+                SuccessCode.COUPON_ISSUED,
+                CouponResponse.IssueRequestResponse.toResponse(result)
+        ));
+    }
 }

--- a/src/main/java/kr/hhplus/be/server/interfaces/api/product/ProductController.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/api/product/ProductController.java
@@ -17,6 +17,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.stream.Collectors;
+
 @Tag(name ="products", description = "상품 API")
 @RestController
 @RequiredArgsConstructor
@@ -52,6 +54,16 @@ public class ProductController {
                 .map(ProductResponse.ProductPopularResponse::toResponse)
                 .toList();
 
+        return ResponseEntity.ok(CustomApiResponse.of(SuccessCode.PRODUCTS_FOUND, response));
+    }
+
+    @Operation(summary = "인기 상품 목록 조회_레디스 캐시 활용", description = "특정 기간의 인기 상품 목록을 조회합니다.")
+    @GetMapping("/redis/popular")
+    public ResponseEntity<CustomApiResponse<List<ProductResponse.ProductPopularResponse>>> getPopularProductsByRedis() {
+        List<ProductResult.ProductPopularResult> results = productFacade.getProductPopularListByRedis();
+        List<ProductResponse.ProductPopularResponse> response = results.stream()
+                .map(ProductResponse.ProductPopularResponse::toResponse)
+                .collect(Collectors.toList());
         return ResponseEntity.ok(CustomApiResponse.of(SuccessCode.PRODUCTS_FOUND, response));
     }
 }

--- a/src/main/java/kr/hhplus/be/server/interfaces/dto/coupon/response/CouponResponse.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/dto/coupon/response/CouponResponse.java
@@ -67,4 +67,15 @@ public class CouponResponse {
             );
         }
     }
+
+    /**
+     * 레디스 쿠폰 발급 요청
+     */
+    public record IssueRequestResponse(
+            String message
+    ) {
+        public static IssueRequestResponse toResponse(CouponResult.IssueRequestResult result) {
+            return new IssueRequestResponse(result.message());
+        }
+    }
 }

--- a/src/main/java/kr/hhplus/be/server/support/schedulers/CouponIssueScheduler.java
+++ b/src/main/java/kr/hhplus/be/server/support/schedulers/CouponIssueScheduler.java
@@ -1,0 +1,93 @@
+package kr.hhplus.be.server.support.schedulers;
+
+import kr.hhplus.be.server.domain.coupon.CouponCacheRepository;
+import kr.hhplus.be.server.domain.coupon.CouponService;
+import kr.hhplus.be.server.domain.coupon.dto.CouponIssueRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CouponIssueScheduler {
+    private final CouponService couponService;
+    private final CouponCacheRepository couponCacheRepository;
+
+    /**
+     * 1초마다 스케줄러를 돌려서 대기중인 쿠폰 발급 요청을 처리
+     * 돌려돌려 돌림판..
+     */
+    @Scheduled(fixedDelay = 1000)
+    public void processCouponRequests() {
+        try {
+            // 활성화된 쿠폰 키 목록 조회 <- 레디스 캐시
+            Set<String> couponKeys = couponCacheRepository.findActiveCouponKeys();
+            // 쿠폰 키에서 아이디 추출
+            List<Long> couponIds = extractCouponIds(couponKeys);
+            // 각 쿠폰 아이디에 대해서 대기중인 발급 요청 처리
+            for (Long couponId : couponIds) {
+                processRequestsForCoupon(couponId);
+            }
+        } catch (Exception e) {
+            log.error("쿠폰 발급 스케줄러 실행 중 오류 발생: {}", e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 쿠폰 아이디에 대한 발급 대기 요청을 처리하는 메서드
+     */
+    private void processRequestsForCoupon(Long couponId) {
+        try {
+            // 재고 캐시가 없으면 DB에서 재고를 읽어와 Redis에 저장 (초기화 진행)
+            int availableStock = couponService.getAvailableStock(couponId);
+            if (availableStock <= 0) {
+                log.info("쿠폰 {} 재고 소진", couponId);
+                // 재고가 소진된 경우, pending request들을 모두 실패 처리 및 큐에서 제거
+                List<CouponIssueRequest> pendingRequests = couponCacheRepository.getPendingRequests(couponId, 1000);
+                for (CouponIssueRequest request : pendingRequests) {
+                    couponCacheRepository.markAsFailed(couponId, request.getUserId());
+                    couponCacheRepository.removeFromRequestQueue(couponId, request.getUserId());
+                }
+                return;
+            }
+
+            // 대기 중인 요청 처리 -> 한 번에 10개의 대기 요청을 처리하도록 수행
+            List<CouponIssueRequest> requests = couponCacheRepository.getPendingRequests(couponId, 10);
+
+            for (CouponIssueRequest request : requests) {
+                try {
+                    // issueCouponByRedis 내부에서 재고 감소를 수행하므로,
+                    // 스케줄러에서는 단순히 해당 요청에 대해 처리 호출
+                    couponService.issueCouponByRedis(request.getUserId(), request.getCouponId());
+                } catch (Exception e) {
+                    log.error("사용자 {}의 쿠폰 발급 요청 처리 실패: {}",
+                            request.getUserId(), e.getMessage());
+                    // 실패 시 요청 큐에서 제거 및 실패 처리
+                    couponCacheRepository.markAsFailed(request.getCouponId(), request.getUserId());
+                    couponCacheRepository.removeFromRequestQueue(request.getCouponId(), request.getUserId());
+                }
+            }
+        } catch (Exception e) {
+            log.error("쿠폰 {} 처리 중 오류 발생: {}", couponId, e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 레디스에서 조회한 쿠폰 키 목록에서 쿠폰 아이디를 추출
+     * key = coupon:1:requests ,
+     */
+    private List<Long> extractCouponIds(Set<String> keys) {
+        return keys.stream()
+                // 쿠폰 ID 추출
+                .map(key -> key.split(":")[1])
+                // Long 타입으로 변환
+                .map(Long::parseLong)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/support/schedulers/PopularProductScheduler.java
+++ b/src/main/java/kr/hhplus/be/server/support/schedulers/PopularProductScheduler.java
@@ -1,0 +1,21 @@
+package kr.hhplus.be.server.support.schedulers;
+
+import kr.hhplus.be.server.domain.product.ProductService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class PopularProductScheduler {
+    private final ProductService productService;
+
+    // 매일 자정에 인기 상품 목록 갱신 - 테스트를 위해 10초로 설정
+    // @Scheduled(cron = "0 0 0 * * *")
+    @Scheduled(fixedDelay = 10000)
+    public void updatePopularProducts(){
+        productService.getPopularProductsByRedis();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,7 +17,7 @@ spring:
     defer-datasource-initialization: true
     show-sql: false
     hibernate:
-      ddl-auto: create
+      ddl-auto: create-drop
     properties:
       hibernate.timezone.default_storage: NORMALIZE_UTC
       hibernate.jdbc.time_zone: UTC
@@ -40,9 +40,9 @@ springdoc:
 
 logging:
   level:
-    root: WARN
-    org.springframework: WARN
-    kr.hhplus: WARN
+    root: INFO
+    org.springframework: INFO
+    kr.hhplus: INFO
   pattern:
     console: "%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level [method=%X{method} uri=%X{uri} requestId=%X{requestId}] %msg%n"
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,6 +21,11 @@ spring:
     properties:
       hibernate.timezone.default_storage: NORMALIZE_UTC
       hibernate.jdbc.time_zone: UTC
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      connect-timeout: 3000
 springdoc:
   api-docs:
     path: /v1/api-docs

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -54,3 +54,10 @@ VALUES
 
     -- 항해 백팩 (1번 주문) - 45000원
     (10, 5, 9, 1, 45000, NOW(), NOW());
+
+-- 5. Coupon
+INSERT INTO coupon (coupon_id, name, discount_price, stock, expired_at, created_at, updated_at)
+VALUES
+    (1, '신규가입 할인 쿠폰', 5000, 10, DATE_ADD(NOW(), INTERVAL 30 DAY), NOW(), NOW()),
+    (2, '여름 시즌 할인 쿠폰', 3000, 20, DATE_ADD(NOW(), INTERVAL 7 DAY), NOW(), NOW()),
+    (3, '품절 임박 할인 쿠폰', 2000, 30, DATE_ADD(NOW(), INTERVAL 3 DAY), NOW(), NOW());

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -24,10 +24,33 @@ VALUES
     (9, '항해 백팩', 45000, 100, 'ON_SALE', NOW(), NOW()),
     (10, '항해 모자', 20000, 100, 'ON_SALE', NOW(), NOW());
 
--- 4. Coupon 애그리거트
--- 4-1. Coupon
-INSERT INTO coupon (coupon_id, name, discount_price, stock, expired_at, created_at, updated_at)
+-- 4. Order 애그리거트
+-- 4-1. Order
+INSERT INTO order_main (order_id, user_id, total_price, status, created_at, updated_at)
 VALUES
-    (1, '신규가입 할인쿠폰', 5000, 100, DATE_ADD(NOW(), INTERVAL 30 DAY), NOW(), NOW()),
-    (2, '여름방학 특별할인', 10000, 50, DATE_ADD(NOW(), INTERVAL 14 DAY), NOW(), NOW()),
-    (3, 'VIP 전용쿠폰', 20000, 10, DATE_ADD(NOW(), INTERVAL 7 DAY), NOW(), NOW());
+    (1, 1, 35000, 'COMPLETED', NOW(), NOW()),
+    (2, 2, 28000, 'COMPLETED', NOW(), NOW()),
+    (3, 1, 53000, 'COMPLETED', NOW(), NOW()),
+    (4, 2, 25000, 'COMPLETED', NOW(), NOW()),
+    (5, 1, 45000, 'COMPLETED', NOW(), NOW());
+
+-- 4-2. OrderLine
+INSERT INTO order_line (order_line_id, order_id, product_id, quantity, total_price, created_at, updated_at)
+VALUES
+    -- 항해 후드티 (3번 주문) - 35000원
+    (1, 1, 1, 1, 35000, NOW(), NOW()),
+    (2, 3, 1, 1, 35000, NOW(), NOW()),
+    (3, 5, 1, 1, 35000, NOW(), NOW()),
+
+    -- 항해 티셔츠 (2번 주문) - 25000원
+    (4, 2, 2, 1, 25000, NOW(), NOW()),
+    (5, 4, 2, 1, 25000, NOW(), NOW()),
+
+    -- 항해 무지노트 (4번 주문) - 3000원
+    (6, 1, 3, 1, 3000, NOW(), NOW()),
+    (7, 2, 3, 1, 3000, NOW(), NOW()),
+    (8, 3, 3, 1, 3000, NOW(), NOW()),
+    (9, 4, 3, 1, 3000, NOW(), NOW()),
+
+    -- 항해 백팩 (1번 주문) - 45000원
+    (10, 5, 9, 1, 45000, NOW(), NOW());

--- a/src/test/java/kr/hhplus/be/server/CouponIssueRedisTest.java
+++ b/src/test/java/kr/hhplus/be/server/CouponIssueRedisTest.java
@@ -1,0 +1,122 @@
+package kr.hhplus.be.server;
+
+
+import kr.hhplus.be.server.application.coupon.CouponFacade;
+import kr.hhplus.be.server.application.coupon.request.CouponCommand;
+import kr.hhplus.be.server.domain.coupon.Coupon;
+import kr.hhplus.be.server.domain.coupon.CouponRepository;
+import kr.hhplus.be.server.domain.user.User;
+import kr.hhplus.be.server.domain.user.UserRepository;
+import kr.hhplus.be.server.infra.coupon.CouponCacheRepositoryImpl;
+import kr.hhplus.be.server.support.schedulers.CouponIssueScheduler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+public class CouponIssueRedisTest {
+    @Autowired
+    private CouponFacade couponFacade;
+
+    @Autowired
+    private CouponIssueScheduler couponIssueScheduler;
+
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private CouponCacheRepositoryImpl couponCacheRepository;
+
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+
+    private List<Long> userIds;
+    private Long testCouponId;
+
+    @BeforeEach
+    public void setup() {
+        // 1. 테스트용 사용자 생성 (100명), 쿠폰 수 보다 많은 유저 수로 테스트 진행
+        userIds = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            User user = User.builder()
+                    .name("TestUser" + i)
+                    .build();
+            userRepository.save(user);
+            userIds.add(user.getUserId());
+        }
+
+        // 2. 테스트용 쿠폰 생성, 재고 10개 고정
+        Coupon coupon = Coupon.builder()
+                .name("테스트 쿠폰")
+                .discountPrice(1000L)
+                .stock(10)
+                .expiredAt(LocalDateTime.now().plusDays(7))
+                .build();
+        coupon = couponRepository.save(coupon);
+        testCouponId = coupon.getCouponId();
+
+        // 3. Redis 초기화
+        couponCacheRepository.setStockCache(testCouponId, coupon.getStock());
+        redisTemplate.delete(String.format("coupon:%d:issued", testCouponId));
+        redisTemplate.delete(String.format("coupon:%d:requests", testCouponId));
+    }
+
+    @Test
+    public void 재고가_10개인_쿠폰에_사용자_50명_동시_발급_요청시_선착순_10명_발급_나머지_40명_실패() throws InterruptedException {
+        int concurrentUsers = 50;
+        CountDownLatch latch = new CountDownLatch(concurrentUsers);
+        ExecutorService executor = Executors.newFixedThreadPool(concurrentUsers);
+
+        // 동시 요청 실행
+        for (int i = 0; i < concurrentUsers; i++) {
+            final Long userId = userIds.get(i);
+            executor.submit(() -> {
+                try {
+                    couponFacade.requestCouponIssue(
+                            new CouponCommand.IssueCoupon(userId, testCouponId)
+                    );
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await(5, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        // 스케줄러 실행
+        couponIssueScheduler.processCouponRequests();
+        Thread.sleep(2000); // 처리 대기
+
+        // 결과 검증
+        int issuedCount = getIssuedCount(testCouponId);
+        assertEquals(10, issuedCount, "발급된 쿠폰 수가 재고량과 일치해야 합니다.");
+
+        Optional<Integer> remainingStock = couponCacheRepository.getStockCache(testCouponId);
+        assertTrue(remainingStock.isPresent());
+        assertEquals(0, remainingStock.get(), "남은 재고가 0이어야 합니다.");
+    }
+
+    private int getIssuedCount(Long couponId) {
+        String issuedKey = String.format("coupon:%d:issued", couponId);
+        Long size = redisTemplate.opsForSet().size(issuedKey);
+        return size != null ? size.intValue() : 0;
+    }
+}


### PR DESCRIPTION
### **7주차 진행 내용**
0. 인기 상품 목록 조회는 변경이 자주 발생하지 않는 조회 서비스입니다. Redis 캐시를 적용하여 DB를 직접적으로 조회하지 않고 캐시를 조회하여 DB 부하를 줄이도록 개선했습니다.
1. 기존에 비관적 락을 활용하여 DB 기반으로 쿠폰 발급 동시성 문제를 해결한 코드에 대해, Redis 캐시를 적용하여 높은 동시 요청 시 DB 부하를 줄이고 성능을 개선했습니다.
2. Redis의 Sorted Set과 Set 자료구조를 활용하여 선착순 쿠폰 요청 등록, 중복 발급 방지, 그리고 재고 관리(증가/감소)를 구현했습니다.
재고 감소 시 Redis 캐시에서 감소 연산을 수행하고, DB 업데이트와 동기화(보상 로직 포함)를 통한 실제 쿠폰 발급 로직을 처리했습니다.
    - 보상 로직 : 캐시에서 재고가 감소한 상태에서 쿠폰 발급에 실패한 경우(중복 발급 요청, 서버 오류) 다시 캐시에 저장된 재고 수량을 증가시키는 로직을 추가했습니다.
3. 재고가 10개인 쿠폰에 대해서, 사용자 50명이 동시에 발급 요청을 진행하는 경우 선착순 10명의 발급은 성공하고 나머지 인원들에 대한 쿠폰 발급은 실패하는 테스트 코드를 작성했습니다.
    - 재고 감소(10개 -> 0개로 감소)
      ![image](https://github.com/user-attachments/assets/f133480c-45fa-43e1-baa0-1949bd9635a4)
    - 발급 성공 유저(10명)
      ![image](https://github.com/user-attachments/assets/86245381-b16b-4d23-bd99-b8272f88aa81)
    - 발급 실패 유저(40명)
      ![image](https://github.com/user-attachments/assets/5cb038a1-952f-45af-8192-b0387fd0016c)





### **커밋 링크**
- 레디스 캐시를 활용한 인기상품 조회  : 278a1cec4f9a4518a4ec341b345e37c1514c3366
- 레디스 캐시를 활용한 쿠폰 발급 및 테스트 코드 : 1be90c53ec7c5bb964951a6bac2a345a2a29afbb
- 보고서 : [Week07 보고서](https://vanilla-pen-0ee.notion.site/Week07_-192e9d02ef3a80968d97f07461d399e5?pvs=4)
<!-- 
좋은 피드백을 받기 위해 가장 중요한 것은 코드를 작성할 때 커밋을 작업 단위로 잘 쪼개는 것입니다.
모든 작업을 하나의 커밋에 진행하고 PR을 하면 구조 파악에 많은 시간을 소모하기 때문에 절대로
좋은 피드백을 받을 수 없습니다.


필수 양식)
커밋 이름 : 커밋 링크

예시)
동시성 처리 : c83845
동시성 테스트 코드 : d93ji3
-->

---
### **리뷰 포인트(질문)**
1. 현재 캐시 관련된 인터페이스는 domain 기준으로 Repository가 생성되어 있고, infra 계층에 인터페이스 구현체를 생성해서 사용하고 있습니다. 레디스 캐시 관련 인터페이스와 구현 코드를 하나의 파일로 생성하는게 더 좋은 방법인지 궁금합니다. 또한 이렇게 캐시를 구현하는 경우 어느 계층에서 구현하여 사용해야 하는지 궁금합니다.(지금 만든 방식이 적절한지 모르겠습니다)
2. 테스트코드에서 레디스 캐시에 저장된 재고와 DB의 재고가 일치하는지, 50명 요청 시 10명은 성공하고 40명은 실패하는지를 검증하고 있습니다. 해당 코드가 동시성을 레디스 캐싱을 활용하여 동작되는지를 확인하는 적절한 코드인지 궁금합니다. 
(10명 성공과 40명 실패는 코드에는 누락되어서 실제 레디스 저장소를 확인하여 검증했습니다) 

<!-- - 리뷰어가 특히 확인해야 할 부분이나 신경 써야 할 코드가 있다면 명확히 작성해주세요.(최대 2개)
  
  좋은 예:
  - `ErrorMessage` 컴포넌트의 상태 업데이트 로직이 적절한지 검토 부탁드립니다.
  - 추가한 유닛 테스트(`LoginError.test.js`)의 테스트 케이스가 충분한지 확인 부탁드립니다.

  나쁜 예:
  - 개선사항을 알려주세요.
  - 코드 전반적으로 봐주세요.
  - 뭘 질문할지 모르겠어요. -->
---
