### PR TITLE
[STEP-15 , STEP-16] 인덱스, 도메인 별 트랜잭션 분리 보고서 및 데이터 플랫폼 전송 이벤트 메시지 기반 수정

### DIFF
--- a/src/main/java/kr/hhplus/be/server/application/port/out/DataPlatformService.java
+++ b/src/main/java/kr/hhplus/be/server/application/port/out/DataPlatformService.java
@@ -1,0 +1,7 @@
+package kr.hhplus.be.server.application.port.out;
+
+import kr.hhplus.be.server.infra.platform.CompletedEvent;
+
+public interface DataPlatformService {
+    void sendPaymentData(CompletedEvent.PaymentCompletedEvent event);
+}

--- a/src/main/java/kr/hhplus/be/server/config/async/AsyncConfig.java
+++ b/src/main/java/kr/hhplus/be/server/config/async/AsyncConfig.java
@@ -1,0 +1,31 @@
+package kr.hhplus.be.server.config.async;
+
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.aop.interceptor.SimpleAsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig implements AsyncConfigurer {
+    @Override
+    public Executor getAsyncExecutor() {
+        // Async가 기본적으로 쓰레드를 생성하는 것이기 때문에 쓰레드풀 만들어서 사용
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(25);
+        executor.setThreadNamePrefix("PaymentEventAsync-");
+        executor.initialize();
+        return executor;
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return new SimpleAsyncUncaughtExceptionHandler();
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/infra/platform/CompletedEvent.java
+++ b/src/main/java/kr/hhplus/be/server/infra/platform/CompletedEvent.java
@@ -1,0 +1,38 @@
+package kr.hhplus.be.server.infra.platform;
+
+import kr.hhplus.be.server.application.payment.response.PaymentResult;
+import kr.hhplus.be.server.domain.payment.Payment;
+import kr.hhplus.be.server.support.constant.PaymentStatus;
+
+import java.time.LocalDateTime;
+
+public class CompletedEvent{
+    public record PaymentCompletedEvent(
+            Long paymentId,
+            Long orderId,
+            Long userId,
+            PaymentStatus status,
+            Long totalAmount,
+            PaymentResult.DiscountInfo discountInfo,
+            Long finalAmount,
+            LocalDateTime completedAt
+
+    ){
+        public static PaymentCompletedEvent of(
+                Payment payment,
+                Long totalAmount,
+                PaymentResult.DiscountInfo discountInfo
+        ) {
+            return new PaymentCompletedEvent(
+                    payment.getPaymentId(),
+                    payment.getOrderId(),
+                    payment.getUserId(),
+                    payment.getStatus(),
+                    totalAmount,
+                    discountInfo,
+                    payment.getPaymentPrice(),
+                    payment.getCreatedAt()
+            );
+        }
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/infra/platform/DataPlatformServiceImpl.java
+++ b/src/main/java/kr/hhplus/be/server/infra/platform/DataPlatformServiceImpl.java
@@ -1,0 +1,14 @@
+package kr.hhplus.be.server.infra.platform;
+
+import kr.hhplus.be.server.application.port.out.DataPlatformService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class DataPlatformServiceImpl implements DataPlatformService {
+    @Override
+    public void sendPaymentData(CompletedEvent.PaymentCompletedEvent event) {
+        log.info("데이터 플랫폼 전송 확인 - Payment Id: {}", event.paymentId());
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/infra/platform/listener/PaymentEventListener.java
+++ b/src/main/java/kr/hhplus/be/server/infra/platform/listener/PaymentEventListener.java
@@ -1,0 +1,30 @@
+package kr.hhplus.be.server.infra.platform.listener;
+
+import kr.hhplus.be.server.application.port.out.DataPlatformService;
+import kr.hhplus.be.server.infra.platform.CompletedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PaymentEventListener {
+    private final DataPlatformService dataPlatformService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handlePaymentCompletedEvent(CompletedEvent.PaymentCompletedEvent event){
+        try{
+            log.info("결제 완료 이벤트 수신 확인 - paymentId: {}, orderId: {}", event.paymentId(), event.orderId());
+
+            dataPlatformService.sendPaymentData(event);
+        } catch (Exception e){
+            log.error("결제 데이터 처리 중 오류 발생", e);
+        }
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/infra/platform/publisher/PaymentEventPublisher.java
+++ b/src/main/java/kr/hhplus/be/server/infra/platform/publisher/PaymentEventPublisher.java
@@ -1,0 +1,19 @@
+package kr.hhplus.be.server.infra.platform.publisher;
+
+import kr.hhplus.be.server.infra.platform.CompletedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PaymentEventPublisher {
+    private final ApplicationEventPublisher eventPublisher;
+
+    public void publishPaymentCompleted(CompletedEvent.PaymentCompletedEvent event){
+        log.info("결제 완료 이벤트 발행 - paymentId: {}", event.paymentId());
+        eventPublisher.publishEvent(event);
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/infra/platform/PaymentEventIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/infra/platform/PaymentEventIntegrationTest.java
@@ -1,0 +1,81 @@
+package kr.hhplus.be.server.infra.platform;
+
+import kr.hhplus.be.server.application.port.out.DataPlatformService;
+import kr.hhplus.be.server.infra.platform.publisher.PaymentEventPublisher;
+import kr.hhplus.be.server.support.constant.PaymentStatus;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Commit;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@SpringBootTest
+public class PaymentEventIntegrationTest {
+
+    @Autowired
+    private PaymentEventPublisher publisher;
+
+    @Mock
+    private DataPlatformService dataPlatformService;
+
+
+    @Test
+    @Transactional
+    @Commit
+    public void 결제_완료_이벤트가_비동기적으로_실행되는지_확인하기위해_이벤트_실행전_실행후_이름_다른지_검증() {
+        // given: 더미 이벤트 생성
+        CompletedEvent.PaymentCompletedEvent event = new CompletedEvent.PaymentCompletedEvent(
+                1L, 1L, 1L, PaymentStatus.PAID, 10000L, null, 10000L, LocalDateTime.now()
+        );
+
+        // 현재 스레드 이름 저장
+        String mainThreadName = Thread.currentThread().getName();
+
+        // 비동기 스레드 이름을 저장할 변수
+        AtomicReference<String> asyncThreadName = new AtomicReference<>();
+
+        // when: 이벤트 발행 -> 비동기 실행
+        publisher.publishPaymentCompleted(event);
+
+        // then: Awaitility를 사용하여 비동기 실행 확인
+        Awaitility.await()
+                .atMost(3, TimeUnit.SECONDS)  // 최대 3초까지 기다리도록 설정
+                .untilAsserted(() -> {
+                    // 비동기 실행 스레드 이름이 변경되었는지 확인
+                    asyncThreadName.set(Thread.currentThread().getName());
+
+                    // 메인 스레드와 비동기 스레드가 다른지 검증
+                    assertThat(asyncThreadName.get()).isNotEqualTo(mainThreadName);
+                });
+    }
+
+    @Test
+    @Transactional
+    @Commit
+    public void 결제_완료_이벤트_비동기_실행_전후_로그_비교() throws InterruptedException {
+        // given: 더미 이벤트 생성
+        CompletedEvent.PaymentCompletedEvent event = new CompletedEvent.PaymentCompletedEvent(
+                1L, 1L, 1L, PaymentStatus.PAID, 10000L, null, 10000L, LocalDateTime.now()
+        );
+
+        // 현재 실행 중인 스레드 이름 출력
+        System.out.println("테스트 => 실행 전 스레드 이름: " + Thread.currentThread().getName());
+
+        // when: 이벤트 발행
+        publisher.publishPaymentCompleted(event);
+
+        // 비동기로 실행 <- 지연 필요
+        Thread.sleep(2000);
+
+        // 테스트 완료 메시지
+        System.out.println("테스트 => 테스트 완료 - 로그의 쓰레드 이름과 출력된 이름이 동일한지 확인.");
+    }
+}


### PR DESCRIPTION
### **8주차 진행 내용**
0. 결제 테이블에 단일 및 복합 인덱스를 추가하고, 인덱스를 사용했을 때와 사용하지 않았을 때의 성능 차이 분석 
1. Spring Events를 활용하여 결제 데이터를 데이터 플랫폼에 이벤트 메시지 기반으로 전송하도록 수정
2. 도메인별로 배포 단위를 분리해야 하는 경우, 분리에 따른 트랜잭션 처리의 한계와 해결방안 분석

### **커밋 링크**
- 결제 정보 데이터 플랫폼 이벤트 메시지 전송  : [6f496b4](https://github.com/HanJeongSeol/hhplus-commerce-repo/pull/13/commits/6f496b43d64045730aca701fb65f76d02030b180)
- 보고서 : [STEP_15 보고서](https://vanilla-pen-0ee.notion.site/STEP-15_-198e9d02ef3a80a894cae7bc5ed03671?pvs=4) , [STEP_16 보고서](https://vanilla-pen-0ee.notion.site/STEP-16_-199e9d02ef3a8056a478ee9e16713359?pvs=4)
<!-- 
좋은 피드백을 받기 위해 가장 중요한 것은 코드를 작성할 때 커밋을 작업 단위로 잘 쪼개는 것입니다.
모든 작업을 하나의 커밋에 진행하고 PR을 하면 구조 파악에 많은 시간을 소모하기 때문에 절대로
좋은 피드백을 받을 수 없습니다.


필수 양식)
커밋 이름 : 커밋 링크

예시)
동시성 처리 : c83845
동시성 테스트 코드 : d93ji3
-->

---
### **리뷰 포인트(질문)**
1. 멘토링에서 복합 인덱스 관련 질문을 답변해 주셨을 때 "범위가 들어가는 녀석이 있다면 맨 뒤로 컬럼을 저장해야 가장 효율적으로 인덱스를 순차적으로 탈 수 있다. 예를 들어, 주문에서 userId(정해진 값)를 먼저 두고, 범위 조건인 주문 일시는 마지막에 배치해야 한다"라고 하셨는데 실제로 아래 쿼리 테스트 진행 시 `created_at`을 가장 앞으로 뒀을 때 성능이 가장 좋았습니다.
    ```javja
    EXPLAIN ANALYZE 
    SELECT * FROM payment_info FORCE INDEX (idx_created_at_status_price)
    WHERE created_at BETWEEN '2025-02-01' AND '2025-02-05' 
    AND status = 'PAID' 
    AND payment_price BETWEEN 6000 AND 8000;
    ```
예상하기로는 전체 데이터의 주문 일시 범위보다 조회 하려는 범위가 현저히 좁기 때문이라고 생각하는데 맞을까요?
2. 


<!-- - 리뷰어가 특히 확인해야 할 부분이나 신경 써야 할 코드가 있다면 명확히 작성해주세요.(최대 2개)
  
  좋은 예:
  - `ErrorMessage` 컴포넌트의 상태 업데이트 로직이 적절한지 검토 부탁드립니다.
  - 추가한 유닛 테스트(`LoginError.test.js`)의 테스트 케이스가 충분한지 확인 부탁드립니다.

  나쁜 예:
  - 개선사항을 알려주세요.
  - 코드 전반적으로 봐주세요.
  - 뭘 질문할지 모르겠어요. -->
---
