### PR TITLE
[STEP-17] 카프카 consumer, producer 연동 및 테스트

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,6 +54,12 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-redis")
 	implementation("org.redisson:redisson-spring-boot-starter:3.27.0")
 
+	// Kafka
+	implementation("org.springframework.kafka:spring-kafka")
+
+	// Test
+	testImplementation("org.springframework.kafka:spring-kafka-test")
+
 	// Test
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.springframework.boot:spring-boot-testcontainers")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,23 +1,142 @@
-version: '3'
+version: '3.8'
+
 services:
   mysql:
     image: mysql:8.0
+    container_name: mysql
+    restart: always
     ports:
       - "3306:3306"
     environment:
-      - MYSQL_ROOT_PASSWORD=root
-      - MYSQL_USER=application
-      - MYSQL_PASSWORD=application
-      - MYSQL_DATABASE=hhplus
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_USER: application
+      MYSQL_PASSWORD: application
+      MYSQL_DATABASE: hhplus
     volumes:
-      - ./data/mysql/:/var/lib/mysql
+      - ./data/mysql:/var/lib/mysql
 
   redis:
     image: redis:7.0
+    container_name: redis
+    restart: always
     ports:
       - "6379:6379"
     volumes:
       - ./data/redis:/data
+
+  zookeeper-1:
+    image: bitnami/zookeeper:latest
+    container_name: zookeeper
+    restart: always
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
+      - ZOO_SERVERS=server.1=zookeeper-1:2888:3888
+    ports:
+      - "2181:2181"
+    networks:
+      - kafka-network
+    volumes:
+      - zookeeper-data-1:/bitnami/zookeeper
+
+  # Kafka Broker 1
+  kafka-1:
+    image: bitnami/kafka:latest
+    container_name: kafka-1
+    restart: always
+    depends_on:
+      - zookeeper-1
+    ports:
+      - "9092:9092"           # 내부 통신용 리스너
+      - "19092:19092"         # 외부 접속용 리스너 (테스트 및 애플리케이션 연동용)
+    environment:
+      - KAFKA_BROKER_ID=1
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper-1:2181
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,EXTERNAL://0.0.0.0:19092
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka-1:9092,EXTERNAL://localhost:19092
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+      - KAFKA_CFG_DEFAULT_REPLICATION_FACTOR=2
+      - KAFKA_CFG_NUM_PARTITIONS=3
+    volumes:
+      - kafka-data-1:/bitnami/kafka
+    networks:
+      - kafka-network
+
+  # Kafka Broker 2
+  kafka-2:
+    image: bitnami/kafka:latest
+    container_name: kafka-2
+    restart: always
+    depends_on:
+      - zookeeper-1
+    ports:
+      - "9093:9093"
+      - "19093:19093"
+    environment:
+      - KAFKA_BROKER_ID=2
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper-1:2181
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9093,EXTERNAL://0.0.0.0:19093
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka-2:9093,EXTERNAL://localhost:19093
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+      - KAFKA_CFG_DEFAULT_REPLICATION_FACTOR=2
+      - KAFKA_CFG_NUM_PARTITIONS=3
+    volumes:
+      - kafka-data-2:/bitnami/kafka
+    networks:
+      - kafka-network
+
+  # Kafka Broker 3
+  kafka-3:
+    image: bitnami/kafka:latest
+    container_name: kafka-3
+    restart: always
+    depends_on:
+      - zookeeper-1
+    ports:
+      - "9094:9094"
+      - "19094:19094"
+    environment:
+      - KAFKA_BROKER_ID=3
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper-1:2181
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9094,EXTERNAL://0.0.0.0:19094
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka-3:9094,EXTERNAL://localhost:19094
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+      - KAFKA_CFG_DEFAULT_REPLICATION_FACTOR=2
+      - KAFKA_CFG_NUM_PARTITIONS=3
+    volumes:
+      - kafka-data-3:/bitnami/kafka
+    networks:
+      - kafka-network
+
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    container_name: kafka-ui
+    restart: always
+    depends_on:
+      - kafka-1
+      - kafka-2
+      - kafka-3
+    ports:
+      - "8081:8080"
+    environment:
+      - KAFKA_CLUSTERS_0_NAME=local-cluster
+      - KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS=kafka-1:9092,kafka-2:9093,kafka-3:9094
+      - KAFKA_CLUSTERS_0_PROPERTIES_SECURITY_PROTOCOL=PLAINTEXT
+      - KAFKA_CLUSTERS_0_ZOOKEEPER=zookeeper-1:2181
+    networks:
+      - kafka-network
+
+volumes:
+  zookeeper-data-1:
+  kafka-data-1:
+  kafka-data-2:
+  kafka-data-3:
+
 networks:
-  default:
+  kafka-network:
     driver: bridge

--- a/src/main/java/kr/hhplus/be/server/infra/kafka/payment/PaymentKafkaProducer.java
+++ b/src/main/java/kr/hhplus/be/server/infra/kafka/payment/PaymentKafkaProducer.java
@@ -1,0 +1,27 @@
+package kr.hhplus.be.server.infra.kafka.payment;
+
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class PaymentKafkaProducer {
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+
+    /**
+     * 지정한 토픽에 메시지 발행.
+     *
+     * @param topic   메시지를 발행할 Kafka 토픽
+     * @param message 발행할 메시지
+     */
+    public void sendMessage(String topic, String message){
+        kafkaTemplate.send(topic, message);
+        log.info("카프카 메시지 전달 : {}", message);
+    }
+
+}

--- a/src/main/java/kr/hhplus/be/server/interfaces/consumer/PaymentKafkaConsumer.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/consumer/PaymentKafkaConsumer.java
@@ -1,0 +1,21 @@
+package kr.hhplus.be.server.interfaces.consumer;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class PaymentKafkaConsumer {
+
+
+    /**
+     * Kafka 토픽으로부터 메시지를 수신
+     *
+     * @param message 수신한 메시지 내용
+     */
+    @KafkaListener(topics = "test-topic", groupId = "my-comsumer-group")
+    public void consume(String message){
+        log.info("카프카 메시지 수신 : {}", message);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,6 +26,24 @@ spring:
       host: localhost
       port: 6379
       connect-timeout: 3000
+
+  kafka:
+    bootstrap-servers: localhost:19092,localhost:19093,localhost:19094
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+      acks: all
+    consumer:
+      group-id: hhplus-consumer-group
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+    listener:
+      ack-mode: batch
+      missing-topics-fatal: false
+    properties:
+      spring.json.trusted.packages: "*"
+
 springdoc:
   api-docs:
     path: /v1/api-docs
@@ -40,9 +58,9 @@ springdoc:
 
 logging:
   level:
-    root: INFO
-    org.springframework: INFO
-    kr.hhplus: INFO
+    root: ERROR
+    org.springframework: ERROR
+    kr.hhplus: ERROR
   pattern:
     console: "%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level [method=%X{method} uri=%X{uri} requestId=%X{requestId}] %msg%n"
 
@@ -58,4 +76,3 @@ spring:
     url: jdbc:mysql://localhost:3306/hhplus?characterEncoding=UTF-8&serverTimezone=UTC
     username: application
     password: application
-

--- a/src/test/java/kr/hhplus/be/server/kafka/KafkaIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/kafka/KafkaIntegrationTest.java
@@ -1,0 +1,95 @@
+package kr.hhplus.be.server.kafka;
+
+import kr.hhplus.be.server.infra.kafka.payment.PaymentKafkaProducer;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.kafka.config.TopicBuilder;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@ActiveProfiles("local")
+public class KafkaIntegrationTest {
+
+    @Autowired
+    private PaymentKafkaProducer producer;
+
+    /**
+     * Docker의 외부 리스너(19092,19093,19094)를 통해 KafkaConsumer를 생성 -> 외부 포트 설정 확인
+     * Consumer는 test-topic을 구독하여 메시지 수신 여부를 확인
+     *  -> 중간에 오류 발생했던 부분 확인 필요
+     */
+    private KafkaConsumer<String, String> createConsumer() {
+        Properties props = new Properties();
+        props.put("bootstrap.servers", "localhost:19092,localhost:19093,localhost:19094");
+        props.put("group.id", "integration-test-group");
+        props.put("enable.auto.commit", "true");
+        props.put("auto.commit.interval.ms", "1000");
+        props.put("key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
+        props.put("value.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
+        // 테스트 시점 이전의 모든 메시지를 읽기 위해 earliest 사용
+        props.put("auto.offset.reset", "earliest");
+        return new KafkaConsumer<>(props);
+    }
+
+    /**
+     * @TestConfiguration 내부에서 KafkaAdmin으로 test-topic을 자동 생성
+     */
+    @TestConfiguration
+    static class KafkaTestConfig {
+        @Bean
+        public NewTopic testTopic() {
+            // 토픽 생성 시 파티션과 복제 개수는 클러스터 상황에 맞게 조정합니다.
+            return TopicBuilder.name("test-topic")
+                    .partitions(3)
+                    .replicas(1)
+                    .build();
+        }
+    }
+
+    @Test
+    public void 직접_생성한_KafkaConsumer로_메시지가_test_topic에_등록되었는지_확인() {
+        String topic = "test-topic";
+        String message = "Test Kafka Message";
+
+        // KafkaConsumer 생성 및 구독
+        KafkaConsumer<String, String> consumer = createConsumer();
+        consumer.subscribe(Collections.singletonList(topic));
+
+        // PaymentKafkaProducer를 이용해 실제 메시지 발행
+        producer.sendMessage(topic, message);
+
+        boolean messageFound = false;
+        long timeout = System.currentTimeMillis() + 10000; // 최대 10초 대기
+
+        // poll()을 통해 메시지 수신 여부 확인
+        while (System.currentTimeMillis() < timeout) {
+            ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(500));
+            for (ConsumerRecord<String, String> record : records) {
+                if (record.value().equals(message)) {
+                    messageFound = true;
+                    break;
+                }
+            }
+            if (messageFound) {
+                break;
+            }
+        }
+        consumer.close();
+
+        // 메시지가 도착했는지 검증 (Kafka-UI에서서 실제 발행 확인 -> 대시보드 좌측 Topic의 Message 탭 확인해서 발행 시간 확인해야 함)
+        assertTrue(messageFound, "Kafka에 메시지가 등록되지 않았습니다.");
+    }
+}


### PR DESCRIPTION
STEP-17 진행 내용
이번 과제에서 사용할 Kafka 개념들을 학습했습니다.
프레임워크에 적용하기 전 CLI를 활용하여 broker, consumer, topic등을 설정하고 실제 이벤트 발행 및 수신 테스트를 진행했습니다.
Kafka-UI를 활용하여 실제 메시지가 전달되었는지 확인.
자세한 내용은 보고서에 작성했습니다.
커밋 링크
docker-compose활용하여 broker, consumer, zookeeper 설정 : 41e9b9388f51e357a2f098dff87a911f11e784ec
consumer, producer 연동 및 통합 테스트 : 40583aefdb7b5206d1acc796023887807bb4aaba
학습 및 실습 보고서 : [STEP_17 보고서](https://vanilla-pen-0ee.notion.site/STEP-17_-19ee9d02ef3a8056a754d256c194222d?pvs=4)
리뷰 포인트(질문)
STEP-18 PR에 작성하겠습니다.